### PR TITLE
fix: stop using brew to install yq

### DIFF
--- a/.github/workflows/schema_validation.yaml
+++ b/.github/workflows/schema_validation.yaml
@@ -11,13 +11,16 @@ jobs:
   validate:
     name: Validate changed files against JSON schema
     runs-on: ubuntu-latest
+    env:
+      YQ_VERSION: "v4.30.8"
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install yq
-        run: |
-          brew install yq
+      - name: Setup yq
+        uses: chrisdickinson/setup-yq@latest
+        with:
+          yq-version: ${{ env.YQ_VERSION }}
       - name: Install jsonschema
         run: |
           python -m pip install jsonschema


### PR DESCRIPTION
It seems that brew is not part of the ubuntu image anymore.