### PR TITLE
chore(RHTAPWATCH-132): segment-bridge image

### DIFF
--- a/rhtap.yaml
+++ b/rhtap.yaml
@@ -5,3 +5,5 @@ mapping:
       repository: quay.io/redhat-appstudio/image-controller
     - name: external-secrets-controller
       repository: quay.io/redhat-appstudio/external-secrets-controller
+    - name: segment-bridge
+      repository: quay.io/redhat-appstudio/segment-bridge


### PR DESCRIPTION
Allow releasing the RHTAP segment-bridge image to quay.io.