### PR TITLE
chore: remove older mce-23 component

### DIFF
--- a/red-hat-acm.yaml
+++ b/red-hat-acm.yaml
@@ -1,7 +1,5 @@
 ---
 mapping:
   components:
-    - name: hypershift-operator-release-413
-      repository: quay.io/acm-d/rhtap-hypershift-operator
     - name: hypershift-operator-main
       repository: quay.io/acm-d/rhtap-hypershift-operator


### PR DESCRIPTION
- name: hypershift-operator-release-413 should not be released.